### PR TITLE
testing context-menu positioning and create a fix

### DIFF
--- a/src/sass/components/_context-menu.scss
+++ b/src/sass/components/_context-menu.scss
@@ -8,6 +8,7 @@
   }
 
   #context-menu {
+    position: fixed !important,
     > ul,
     > ul > li > ul {
       @include nice-shadow(2);


### PR DESCRIPTION
Hi,

thanks for your awesome template. With an update to 4.2.7 I detected wrong positioning of the context menu. I am not a web developer, but I think, my fix could work. Can you take a look onto it and tell me, if this is working for you, please? Would be nice to give back :)

Thank you