### PR TITLE
Add back columns to "add member" window

### DIFF
--- a/src/sass/components/_elements.scss
+++ b/src/sass/components/_elements.scss
@@ -264,6 +264,16 @@ img {
   }
 }
 
+.objects-selection {
+  overflow: auto;
+  margin-bottom: 1em;
+  
+  div {
+    column-count: auto;
+    column-width: 400px;
+  }
+}
+
 .roles-selection {
   label {
     @include check-inline;


### PR DESCRIPTION
Before: (one big column)
![grafik](https://github.com/user-attachments/assets/6f9f4a36-2b3b-4882-91d0-293f69d58c97)

After: (multiple columns, just like default redmine)
![grafik](https://github.com/user-attachments/assets/c5102888-1010-47cd-aca4-b428ebc63382)